### PR TITLE
chore(stepsecurity): update workflows to use custom hosted runners with built-in StepSecurity

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,45 +29,45 @@ env:
 jobs:
   fmt:
     name: Formatting
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-small
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
           components: rustfmt
       - name: Check formatting
-        uses: actions-rust-lang/rustfmt@v1
+        uses: actions-rust-lang/rustfmt@559aa3035a47390ba96088dffa783b5d26da9326 # v1.1.1
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-small
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
           components: clippy
       - name: Run clippy
-        uses: auguwu/clippy-action@1.4.0
+        uses: auguwu/clippy-action@94a9ff2f6920180b89e5c03d121d0af04a9d3e03 # 1.4.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # doc:
   #   name: Doc
-  #   runs-on: ubuntu-latest
+  #   runs-on: github-hosted-small
   #   env:
   #     RUSTDOCFLAGS: -Dwarnings
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
   #     - name: Setup Rust toolchain
-  #       uses: actions-rust-lang/setup-rust-toolchain@v1
+  #       uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
   #       with:
   #         # Run docs generation on nightly rather than stable. This enables features like
   #         # https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html which allows an

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,18 +27,18 @@ env:
 jobs:
   unit:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-small
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@cargo-nextest
+        uses: taiki-e/install-action@3a420b1bc49f1aa6ea12063d319cb1985146beef # cargo-nextest
       - name: Run tests
         run: |
           cargo nextest run \


### PR DESCRIPTION
## Summary
This PR updates GitHub Actions workflows to use custom hosted runners that have StepSecurity built-in, removing the need for the explicit StepSecurity harden-runner action.

## What Changed
Removed step-security/harden-runner action steps (no longer needed as StepSecurity is built into custom runners)
Removed id-token: write permissions (no longer needed without the StepSecurity action)
Updated runs-on from ubuntu-latest to github-hosted-small (custom runners with built-in StepSecurity)
Converted non-circlefin action versions to commit SHAs with version comments for security pinning (e.g., actions/checkout@abc123 # v3.6.0)
circlefin GitHub actions remain unchanged
Purpose
Our custom hosted runners (github-hosted-small) now have StepSecurity built-in at the runner level, so we no longer need to add it as an explicit step in each workflow. This simplifies our workflows while maintaining the same security posture.

## Testing
All workflow syntax changes have been validated
No functional changes to workflow behavior
StepSecurity protection is maintained via the custom runners
Review the diff to ensure only intended changes occurred